### PR TITLE
Fix bug in Response that was looking for bad error property name

### DIFF
--- a/library/ZendService/Twitter/Response.php
+++ b/library/ZendService/Twitter/Response.php
@@ -124,13 +124,13 @@ class Response
             return [];
         }
         if (null === $this->jsonBody
-            || ! isset($this->jsonBody->errors)
+            || ! isset($this->jsonBody->error)
         ) {
             throw new Exception\DomainException(
                 'Either no JSON response received, or JSON error response is malformed; cannot return errors'
             );
         }
-        return $this->jsonBody->errors;
+        return $this->jsonBody->error;
     }
 
     /**

--- a/tests/ZendService/Twitter/TwitterTest.php
+++ b/tests/ZendService/Twitter/TwitterTest.php
@@ -739,6 +739,19 @@ class TwitterTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(15012215, $payload[0]->id);
     }
 
+    public function testBadResponseErrorHandling()
+    {
+        $twitter = new Twitter\Twitter;
+        $twitter->setHttpClient($this->stubTwitter(
+            'statuses/update.json',
+            Http\Request::METHOD_POST,
+            'bad.response.json',
+            ['status' => 'Test Message 1']
+        ));
+        $response = $twitter->statuses->update('Test Message 1');
+        $this->assertEquals($response->getErrors(), "Read-only application cannot POST.");
+    }
+
     public function providerAdapterAlwaysReachableIfSpecifiedConfiguration()
     {
         $adapter = new CurlAdapter();

--- a/tests/ZendService/Twitter/_files/bad.response.json
+++ b/tests/ZendService/Twitter/_files/bad.response.json
@@ -1,0 +1,4 @@
+{
+  "request": "\/1.1\/media\/upload.json",
+  "error": "Read-only application cannot POST."
+}


### PR DESCRIPTION
When processing `getErrors()` the Response code checks for `$this->jsonBody->errors`.

I ran into a twitter issue where I needed to dig into the error message and found that the property that should be checked is `$this->jsonBody->error`.

Example Failure from Twitter API when uploading media.

```
class stdClass#106 (2) {
  public $request =>
  string(22) "/1.1/media/upload.json"
  public $error =>
  string(34) "Read-only application cannot POST."
}
```

The only response docs around errors seems to be https://dev.twitter.com/ads/basics/response-codes which notes an `errors` property. Not sure if this related code should be checking for `errors` AND `error` or not.
